### PR TITLE
Update links

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -2,13 +2,13 @@
 _commit: v4.4.0
 _src_path: https://github.com/jupyterlab/extension-template
 author_email: ''
-author_name: Jeremy Tuloup
+author_name: Project Jupyter
 has_binder: false
 has_settings: true
 kind: frontend
 labextension_name: jupyterlab-ai-commands
 project_short_description: A set of commands for AI in JupyterLab
 python_name: jupyterlab_ai_commands
-repository: https://github.com/jtpio/jupyterlab-ai-commands
+repository: https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands
 test: true
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,15 @@
 
 ## 0.1.2
 
-([Full Changelog](https://github.com/jtpio/jupyterlab-ai-commands/compare/v0.1.1...22a6a404c6bd1e2efff3e377108c77c4935fde9f))
+([Full Changelog](https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/compare/v0.1.1...22a6a404c6bd1e2efff3e377108c77c4935fde9f))
 
 ### Enhancements made
 
-- Add `list-directory` [#1](https://github.com/jtpio/jupyterlab-ai-commands/pull/1) ([@jtpio](https://github.com/jtpio))
+- Add `list-directory` [#1](https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/pull/1) ([@jtpio](https://github.com/jtpio))
 
 ### Contributors to this release
 
-([GitHub contributors page for this release](https://github.com/jtpio/jupyterlab-ai-commands/graphs/contributors?from=2025-10-30&to=2025-10-31&type=c))
+([GitHub contributors page for this release](https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/graphs/contributors?from=2025-10-30&to=2025-10-31&type=c))
 
 [@jtpio](https://github.com/search?q=repo%3Ajtpio%2Fjupyterlab-ai-commands+involves%3Ajtpio+updated%3A2025-10-30..2025-10-31&type=Issues)
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 BSD 3-Clause License
 
 Copyright (c) 2025, Jeremy Tuloup
+Copyright (c) 2025, Project Jupyter
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jupyterlab-ai-commands
 
-[![Github Actions Status](https://github.com/jtpio/jupyterlab-ai-commands/workflows/Build/badge.svg)](https://github.com/jtpio/jupyterlab-ai-commands/actions/workflows/build.yml)
+[![Github Actions Status](https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/workflows/Build/badge.svg)](https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/actions/workflows/build.yml)
 
 A set of commands for AI in JupyterLab
 

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
         "jupyterlab",
         "jupyterlab-extension"
     ],
-    "homepage": "https://github.com/jtpio/jupyterlab-ai-commands",
+    "homepage": "https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands",
     "bugs": {
-        "url": "https://github.com/jtpio/jupyterlab-ai-commands/issues"
+        "url": "https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands/issues"
     },
     "license": "BSD-3-Clause",
-    "author": "Jeremy Tuloup",
+    "author": "Project Jupyter",
     "files": [
         "lib/**/*.{d.ts,eot,gif,html,jpg,js,js.map,json,png,svg,woff2,ttf}",
         "style/**/*.{css,js,eot,gif,html,jpg,json,png,svg,woff2,ttf}",
@@ -24,7 +24,7 @@
     "style": "style/index.css",
     "repository": {
         "type": "git",
-        "url": "https://github.com/jtpio/jupyterlab-ai-commands.git"
+        "url": "https://github.com/jupyter-ai-contrib/jupyterlab-ai-commands.git"
     },
     "scripts": {
         "build": "jlpm build:lib && jlpm build:labextension:dev",


### PR DESCRIPTION
Follow-up to the move to `jupyter-ai-contrib`.