### PR TITLE
Remove explicit Node 24 from publish-release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -20,8 +20,6 @@ jobs:
       id-token: write
     steps:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
-        with:
-          node_version: '24'
 
       - uses: actions/create-github-app-token@v1
         id: app-token


### PR DESCRIPTION
This should not be needed anymore after https://github.com/jupyterlab/maintainer-tools/pull/264