### PR TITLE
Get notebook metadata in get-notebook-info command

### DIFF
--- a/src/notebook-commands.ts
+++ b/src/notebook-commands.ts
@@ -282,6 +282,7 @@ function registerGetNotebookInfoCommand(
       const activeCellIndex = notebook.activeCellIndex;
       const activeCell = notebook.activeCell;
       const activeCellType = activeCell?.model.type || 'unknown';
+      const notebookMetadata = model.metadata;
 
       return {
         success: true,
@@ -290,6 +291,7 @@ function registerGetNotebookInfoCommand(
         cellCount,
         activeCellIndex,
         activeCellType,
+        notebookMetadata,
         isDirty: model.dirty
       };
     }


### PR DESCRIPTION
This PR adds the notebook metadata to the data returned by `get-notebook-info` command.
This will be helpful to retrieve the kernel language associated to the Notebook.

[output.webm](https://github.com/user-attachments/assets/0e4dc8fd-ad0c-4c84-939b-8a41dbf6095d)

Maybe we could filter the metadata to the `language_info` and `kernelspec` by default, and add an argument to the commands to explicitly retrieve all the metadata ?

Related to https://github.com/jupyterlite/ai/pull/255