### PR TITLE
Get content without opening widget

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
         "watch:labextension": "jupyter labextension watch ."
     },
     "dependencies": {
+        "@jupyter/ydoc": "^3.1.0",
         "@jupyterlab/application": "^4.0.0",
         "@jupyterlab/apputils": "^4.0.0",
         "@jupyterlab/cells": "^4.0.0",

--- a/src/file-commands.ts
+++ b/src/file-commands.ts
@@ -573,6 +573,12 @@ function registerGetFileInfoCommand(
       const resolvedFilePath = widget?.context.path ?? filePath;
       const fileName = widget?.title.label ?? PathExt.basename(filePath);
       const fileExtension = PathExt.extname(resolvedFilePath) || 'unknown';
+      const isDirty = model.dirty;
+      const readOnly = model.readOnly;
+
+      if (!widget) {
+        context.dispose();
+      }
 
       return {
         success: true,
@@ -580,8 +586,8 @@ function registerGetFileInfoCommand(
         fileName,
         fileExtension,
         content,
-        isDirty: model.dirty,
-        readOnly: model.readOnly,
+        isDirty,
+        readOnly,
         widgetType: widget?.constructor.name
       };
     }

--- a/src/file-commands.ts
+++ b/src/file-commands.ts
@@ -1,8 +1,14 @@
 import { PathExt } from '@jupyterlab/coreutils';
-import { CommandRegistry } from '@lumino/commands';
 import { IDocumentManager } from '@jupyterlab/docmanager';
-import { DocumentWidget, IDocumentWidget } from '@jupyterlab/docregistry';
+import {
+  Context,
+  DocumentRegistry,
+  DocumentWidget,
+  IDocumentWidget
+} from '@jupyterlab/docregistry';
 import { IEditorTracker } from '@jupyterlab/fileeditor';
+import { ServiceManager } from '@jupyterlab/services';
+import { CommandRegistry } from '@lumino/commands';
 
 /**
  * Command IDs for diff management (from jupyterlab-diff)
@@ -14,23 +20,48 @@ const BACKGROUND_DESCRIPTION =
 /**
  * Helper function to get a document widget by path or use the active one
  */
-function getDocumentWidget(
+async function getDocumentWidget(
   filepath: string,
   docManager: IDocumentManager,
-  background?: boolean
-): DocumentWidget {
+  background?: boolean,
+  createWidget = true
+): Promise<DocumentWidget | null> {
   let widget = docManager.findWidget(filepath);
-  if (!widget) {
+  if (!widget && createWidget) {
     widget = docManager.openOrReveal(filepath, undefined, undefined, {
       activate: !(background ?? true)
     });
   }
 
-  if (!(widget instanceof DocumentWidget)) {
+  if (!(widget instanceof DocumentWidget) && createWidget) {
     throw new Error(`Widget for ${filepath} is not a document widget`);
   }
+  await widget?.context.ready;
 
-  return widget;
+  return (widget as DocumentWidget) ?? null;
+}
+
+/**
+ * Helper function to get a document context without widget
+ */
+async function getDocumentContext(
+  docManager: IDocumentManager,
+  manager: ServiceManager.IManager,
+  path: string
+): Promise<DocumentRegistry.IContext<DocumentRegistry.IModel> | null> {
+  const { registry } = docManager;
+  const modelName = registry.defaultWidgetFactory(path).modelName;
+  if (!modelName) {
+    return null;
+  }
+  const factory = registry.getModelFactory(modelName);
+  if (!factory) {
+    return null;
+  }
+  const context = new Context({ manager, factory, path });
+  await context.initialize(false);
+  await context.ready;
+  return context;
 }
 
 /**
@@ -123,7 +154,7 @@ function registerCreateFileCommand(
       }
 
       let opened = false;
-      if (getDocumentWidget(finalPath, docManager, background)) {
+      if (await getDocumentWidget(finalPath, docManager, background)) {
         opened = true;
       }
 
@@ -179,7 +210,7 @@ function registerOpenFileCommand(
         throw new Error(`File not found: ${filePath}`);
       }
 
-      const widget = getDocumentWidget(filePath, docManager, background);
+      const widget = await getDocumentWidget(filePath, docManager, background);
 
       if (!widget) {
         throw new Error(`Could not open file: ${filePath}`);
@@ -458,7 +489,8 @@ function registerListDirectoryCommand(
 function registerGetFileInfoCommand(
   commands: CommandRegistry,
   docManager: IDocumentManager,
-  editorTracker?: IEditorTracker
+  editorTracker?: IEditorTracker,
+  serviceManager?: ServiceManager.IManager
 ): void {
   const command = {
     id: 'jupyterlab-ai-commands:get-file-info',
@@ -476,24 +508,49 @@ function registerGetFileInfoCommand(
           background: {
             type: 'boolean',
             description: BACKGROUND_DESCRIPTION
+          },
+          createWidget: {
+            type: 'boolean',
+            description:
+              'Whether to open the document widget if it is not opened. Default to false to avoid unnecessary disruption'
           }
         }
       }
     },
     execute: async (args: any) => {
-      const { filePath, background } = args;
+      const { filePath, background, createWidget } = args;
 
       let widget: IDocumentWidget | null = null;
+      let context: DocumentRegistry.IContext<DocumentRegistry.IModel> | null =
+        null;
 
       if (filePath) {
-        widget = getDocumentWidget(filePath, docManager, background);
+        widget = await getDocumentWidget(
+          filePath,
+          docManager,
+          background,
+          (createWidget ?? false) || !serviceManager
+        );
+        context = widget?.context ?? null;
 
         if (!widget) {
-          throw new Error(`Failed to open file at path: ${filePath}`);
+          if (createWidget) {
+            throw new Error(`Failed to open file at path: ${filePath}`);
+          } else if (serviceManager) {
+            context = await getDocumentContext(
+              docManager,
+              serviceManager,
+              filePath
+            );
+          } else {
+            throw new Error(
+              `Failed to get the content of ${filePath}, the service manager is not available`
+            );
+          }
         }
       } else {
         widget = editorTracker?.currentWidget ?? null;
-
+        context = widget?.context ?? null;
         if (!widget) {
           throw new Error(
             'No active file in the editor and no file path provided'
@@ -501,13 +558,11 @@ function registerGetFileInfoCommand(
         }
       }
 
-      if (!widget.context) {
+      if (!context) {
         throw new Error('Widget is not a document');
       }
 
-      await widget.context.ready;
-
-      const model = widget.context.model;
+      const model = context.model;
 
       if (!model) {
         throw new Error('File model not available');
@@ -515,8 +570,8 @@ function registerGetFileInfoCommand(
 
       const sharedModel = model.sharedModel;
       const content = sharedModel.getSource();
-      const resolvedFilePath = widget.context.path;
-      const fileName = widget.title.label;
+      const resolvedFilePath = widget?.context.path ?? filePath;
+      const fileName = widget?.title.label ?? PathExt.basename(filePath);
       const fileExtension = PathExt.extname(resolvedFilePath) || 'unknown';
 
       return {
@@ -527,7 +582,7 @@ function registerGetFileInfoCommand(
         content,
         isDirty: model.dirty,
         readOnly: model.readOnly,
-        widgetType: widget.constructor.name
+        widgetType: widget?.constructor.name
       };
     }
   };
@@ -585,13 +640,11 @@ function registerSetFileContentCommand(
         showDiff = true
       } = args;
 
-      const widget = getDocumentWidget(filePath, docManager, background);
+      const widget = await getDocumentWidget(filePath, docManager, background);
 
       if (!widget) {
         throw new Error(`Failed to open file at path: ${filePath}`);
       }
-
-      await widget.context.ready;
 
       const model = widget.context.model;
 
@@ -644,6 +697,7 @@ export interface IRegisterFileCommandsOptions {
   commands: CommandRegistry;
   docManager: IDocumentManager;
   editorTracker?: IEditorTracker;
+  serviceManager?: ServiceManager.IManager;
 }
 
 /**
@@ -652,7 +706,7 @@ export interface IRegisterFileCommandsOptions {
 export function registerFileCommands(
   options: IRegisterFileCommandsOptions
 ): void {
-  const { commands, docManager, editorTracker } = options;
+  const { commands, docManager, editorTracker, serviceManager } = options;
 
   registerCreateFileCommand(commands, docManager);
   registerOpenFileCommand(commands, docManager);
@@ -661,6 +715,11 @@ export function registerFileCommands(
   registerCopyFileCommand(commands, docManager);
   registerNavigateToDirectoryCommand(commands);
   registerListDirectoryCommand(commands, docManager);
-  registerGetFileInfoCommand(commands, docManager, editorTracker);
+  registerGetFileInfoCommand(
+    commands,
+    docManager,
+    editorTracker,
+    serviceManager
+  );
   registerSetFileContentCommand(commands, docManager);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,15 +30,15 @@ const plugin: JupyterFrontEndPlugin<void> = {
   ) => {
     console.log('JupyterLab extension jupyterlab-ai-commands is activated!');
 
-    const commands = app.commands;
+    const { commands, serviceManager } = app;
 
     registerFileCommands({
       commands,
       docManager,
-      editorTracker
+      editorTracker,
+      serviceManager
     });
 
-    const serviceManager = app.serviceManager;
     registerNotebookCommands({
       commands,
       docManager,

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,11 +38,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
       editorTracker
     });
 
-    const kernelSpecManager = app.serviceManager.kernelspecs;
+    const serviceManager = app.serviceManager;
     registerNotebookCommands({
       commands,
       docManager,
-      kernelSpecManager,
+      serviceManager,
       notebookTracker
     });
 
@@ -50,7 +50,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     registerKernelCommands({
       commands,
       kernelManager,
-      kernelSpecManager
+      kernelSpecManager: serviceManager.kernelspecs
     });
 
     if (settingRegistry) {

--- a/src/notebook-commands.ts
+++ b/src/notebook-commands.ts
@@ -425,11 +425,13 @@ function registerGetNotebookInfoCommand(
               ? `Failed to open notebook at path: ${notebookPath}`
               : 'No active notebook and no notebook path provided'
           );
-        } else if (serviceManager) {
+        } else if (serviceManager && notebookPath) {
           context = await getNotebookContext(serviceManager, notebookPath);
         } else {
           throw new Error(
-            `Failed to get the content of ${notebookPath}, the service manager is not available`
+            notebookPath
+              ? `Failed to get the content of ${notebookPath}, the service manager is not available`
+              : 'No active notebook and no notebook path provided'
           );
         }
       }
@@ -537,11 +539,13 @@ function registerGetCellInfoCommand(
               ? `Failed to open notebook at path: ${notebookPath}`
               : 'No active notebook and no notebook path provided'
           );
-        } else if (serviceManager) {
+        } else if (serviceManager && notebookPath) {
           context = await getNotebookContext(serviceManager, notebookPath);
         } else {
           throw new Error(
-            `Failed to get the content of ${notebookPath}, the service manager is not available`
+            notebookPath
+              ? `Failed to get the content of ${notebookPath}, the service manager is not available`
+              : 'No active notebook and no notebook path provided'
           );
         }
       }

--- a/src/notebook-commands.ts
+++ b/src/notebook-commands.ts
@@ -1,18 +1,21 @@
+import type { YNotebook } from '@jupyter/ydoc';
 import {
   CodeCell,
   ICellModel,
   ICodeCellModel,
   MarkdownCell
 } from '@jupyterlab/cells';
+import { PathExt } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
+import { Context, DocumentRegistry } from '@jupyterlab/docregistry';
 import * as nbformat from '@jupyterlab/nbformat';
 import {
   INotebookModel,
   INotebookTracker,
+  NotebookModelFactory,
   NotebookPanel
 } from '@jupyterlab/notebook';
-import type { YNotebook } from '@jupyter/ydoc';
-import { KernelSpec } from '@jupyterlab/services';
+import { KernelSpec, ServiceManager } from '@jupyterlab/services';
 import { CommandRegistry } from '@lumino/commands';
 
 import { findKernelByLanguage } from './kernel-utils';
@@ -45,38 +48,44 @@ function getErrorOutput(
 /**
  * Helper function to get a notebook widget by path or use the active one
  */
-function getNotebookWidget(
+async function getNotebookWidget(
   notebookPath: string | null | undefined,
   docManager: IDocumentManager,
   notebookTracker?: INotebookTracker,
-  background?: boolean
-): NotebookPanel | null {
+  background?: boolean,
+  createWidget = true
+): Promise<NotebookPanel | null> {
   if (notebookPath) {
     let widget = docManager.findWidget(notebookPath);
-    if (!widget) {
+    if (!widget && createWidget) {
       widget = docManager.openOrReveal(notebookPath, 'default', undefined, {
         activate: !(background ?? true)
       });
     }
 
-    if (!(widget instanceof NotebookPanel)) {
+    if (!(widget instanceof NotebookPanel) && createWidget) {
       throw new Error(`Widget for ${notebookPath} is not a notebook panel`);
     }
+    await widget?.context.ready;
 
-    return widget ?? null;
+    return (widget as NotebookPanel) ?? null;
   } else {
     return notebookTracker?.currentWidget || null;
   }
 }
 
-function getNotebookModel(notebookPanel: NotebookPanel): INotebookModel {
-  const model = notebookPanel.content.model;
-
-  if (!model) {
-    throw new Error('No notebook model available');
-  }
-
-  return model;
+/**
+ * Helper function to get a notebook context without widget
+ */
+async function getNotebookContext(
+  manager: ServiceManager.IManager,
+  path: string
+): Promise<DocumentRegistry.IContext<INotebookModel>> {
+  const factory = new NotebookModelFactory();
+  const context = new Context({ manager, factory, path });
+  await context.initialize(false);
+  await context.ready;
+  return context;
 }
 
 function findCellIndexById(model: INotebookModel, cellId: string): number {
@@ -90,20 +99,18 @@ function findCellIndexById(model: INotebookModel, cellId: string): number {
 }
 
 function getCellTarget(
-  notebookPanel: NotebookPanel,
-  cellId?: string | null
+  notebookModel: INotebookModel,
+  cellId?: string | null,
+  notebookPanel?: NotebookPanel | null
 ): { cell: ICellModel; cellIndex: number } {
-  const notebook = notebookPanel.content;
-  const model = getNotebookModel(notebookPanel);
-
   if (cellId !== undefined && cellId !== null) {
-    const cellIndex = findCellIndexById(model, cellId);
+    const cellIndex = findCellIndexById(notebookModel, cellId);
 
     if (cellIndex === -1) {
       throw new Error(`Cell with ID '${cellId}' not found in notebook`);
     }
 
-    const cell = model.cells.get(cellIndex);
+    const cell = notebookModel.cells.get(cellIndex);
     if (!cell) {
       throw new Error(`Cell with ID '${cellId}' not found in notebook`);
     }
@@ -111,12 +118,17 @@ function getCellTarget(
     return { cell, cellIndex };
   }
 
-  const cellIndex = notebook.activeCellIndex;
-  if (cellIndex === -1 || cellIndex >= model.cells.length) {
+  const notebook = notebookPanel?.content;
+  const cellIndex = notebook?.activeCellIndex;
+  if (
+    cellIndex === undefined ||
+    cellIndex === -1 ||
+    cellIndex >= notebookModel.cells.length
+  ) {
     throw new Error('No active cell or invalid active cell index');
   }
 
-  const cell = model.cells.get(cellIndex);
+  const cell = notebookModel.cells.get(cellIndex);
   if (!cell) {
     throw new Error(`Cell at active index ${cellIndex} not found`);
   }
@@ -194,7 +206,7 @@ function registerCreateNotebookCommand(
       await notebook.context.ready;
 
       // Persist cell IDs by saving newly created notebooks as nbformat 4.5+.
-      const model = getNotebookModel(notebook);
+      const model = notebook.context.model;
       const sharedModel = model.sharedModel as YNotebook;
       if (sharedModel.nbformat_minor < 5) {
         sharedModel.nbformat_minor = 5;
@@ -274,7 +286,7 @@ function registerAddCellCommand(
         position = 'below'
       } = args;
 
-      const currentWidget = getNotebookWidget(
+      const currentWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
@@ -289,7 +301,7 @@ function registerAddCellCommand(
       }
 
       const notebook = currentWidget.content;
-      const model = getNotebookModel(currentWidget);
+      const model = currentWidget.context.model;
 
       if (!VALID_CELL_TYPES.has(cellType)) {
         throw new Error(
@@ -313,8 +325,9 @@ function registerAddCellCommand(
         insertIndex = 0;
       } else if (model.cells.length > 0) {
         const { cellIndex: referenceCellIndex } = getCellTarget(
-          currentWidget,
-          referenceCellId
+          model,
+          referenceCellId,
+          currentWidget
         );
 
         insertIndex =
@@ -364,7 +377,8 @@ function registerAddCellCommand(
 function registerGetNotebookInfoCommand(
   commands: CommandRegistry,
   docManager: IDocumentManager,
-  notebookTracker?: INotebookTracker
+  notebookTracker?: INotebookTracker,
+  serviceManager?: ServiceManager.IManager
 ): void {
   const command = {
     id: 'jupyterlab-ai-commands:get-notebook-info',
@@ -383,32 +397,52 @@ function registerGetNotebookInfoCommand(
           background: {
             type: 'boolean',
             description: BACKGROUND_DESCRIPTION
+          },
+          createWidget: {
+            type: 'boolean',
+            description:
+              'Whether to open the Notebook widget if it is not opened. Default to false to avoid unnecessary disruption'
           }
         }
       }
     },
-    execute: (args: any) => {
-      const { notebookPath, background } = args;
+    execute: async (args: any) => {
+      const { notebookPath, background, createWidget } = args;
 
-      const currentWidget = getNotebookWidget(
+      const currentWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
-        background
+        background,
+        // Create the Notebook widget if explicitly requested or if the service manager is not available.
+        (createWidget ?? false) || !serviceManager
       );
+      let context = currentWidget?.context;
       if (!currentWidget) {
-        throw new Error(
-          notebookPath
-            ? `Failed to open notebook at path: ${notebookPath}`
-            : 'No active notebook and no notebook path provided'
-        );
+        if (createWidget) {
+          throw new Error(
+            notebookPath
+              ? `Failed to open notebook at path: ${notebookPath}`
+              : 'No active notebook and no notebook path provided'
+          );
+        } else if (serviceManager) {
+          context = await getNotebookContext(serviceManager, notebookPath);
+        } else {
+          throw new Error(
+            `Failed to get the content of ${notebookPath}, the service manager is not available`
+          );
+        }
       }
 
-      const notebook = currentWidget.content;
-      const model = getNotebookModel(currentWidget);
+      if (!context) {
+        throw new Error(`Failed to get the context of ${notebookPath}`);
+      }
+
+      const notebook = currentWidget?.content;
+      const model = context.model;
 
       const cellCount = model.cells.length;
-      const activeCell = notebook.activeCell;
+      const activeCell = notebook?.activeCell;
       const activeCellId = activeCell?.model.id || null;
       const activeCellType = activeCell?.model.type || 'unknown';
       const cells = Array.from({ length: cellCount }, (_, index) => {
@@ -420,11 +454,11 @@ function registerGetNotebookInfoCommand(
         };
       });
       const notebookMetadata = model.metadata;
-
       return {
         success: true,
-        notebookName: currentWidget.title.label,
-        notebookPath: currentWidget.context.path,
+        notebookName:
+          currentWidget?.title.label ?? PathExt.basename(notebookPath),
+        notebookPath: currentWidget?.context.path ?? notebookPath,
         cellCount,
         activeCellId,
         activeCellType,
@@ -444,7 +478,8 @@ function registerGetNotebookInfoCommand(
 function registerGetCellInfoCommand(
   commands: CommandRegistry,
   docManager: IDocumentManager,
-  notebookTracker?: INotebookTracker
+  notebookTracker?: INotebookTracker,
+  serviceManager?: ServiceManager.IManager
 ): void {
   const command = {
     id: 'jupyterlab-ai-commands:get-cell-info',
@@ -468,28 +503,49 @@ function registerGetCellInfoCommand(
           background: {
             type: 'boolean',
             description: BACKGROUND_DESCRIPTION
+          },
+          createWidget: {
+            type: 'boolean',
+            description:
+              'Whether to open the Notebook widget if it is not opened. Default to false to avoid unnecessary disruption'
           }
         }
       }
     },
-    execute: (args: any) => {
-      const { notebookPath, cellId, background } = args;
+    execute: async (args: any) => {
+      const { notebookPath, cellId, background, createWidget } = args;
 
-      const currentWidget = getNotebookWidget(
+      const currentWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
-        background
+        background,
+        // Create the Notebook widget if explicitly requested or if the service manager is not available.
+        (createWidget ?? false) || !serviceManager
       );
+      let context = currentWidget?.context;
       if (!currentWidget) {
-        throw new Error(
-          notebookPath
-            ? `Failed to open notebook at path: ${notebookPath}`
-            : 'No active notebook and no notebook path provided'
-        );
+        if (createWidget) {
+          throw new Error(
+            notebookPath
+              ? `Failed to open notebook at path: ${notebookPath}`
+              : 'No active notebook and no notebook path provided'
+          );
+        } else if (serviceManager) {
+          context = await getNotebookContext(serviceManager, notebookPath);
+        } else {
+          throw new Error(
+            `Failed to get the content of ${notebookPath}, the service manager is not available`
+          );
+        }
       }
 
-      const { cell } = getCellTarget(currentWidget, cellId);
+      if (!context) {
+        throw new Error(`Failed to get the context of ${notebookPath}`);
+      }
+
+      const model = context.model;
+      const { cell } = getCellTarget(model, cellId, currentWidget);
       const cellType = cell.type;
       const sharedModel = cell.sharedModel;
       const source = sharedModel.getSource();
@@ -563,7 +619,7 @@ function registerSetCellContentCommand(
         required: ['content']
       }
     },
-    execute: (args: any) => {
+    execute: async (args: any) => {
       const {
         notebookPath,
         cellId,
@@ -573,7 +629,7 @@ function registerSetCellContentCommand(
         diffMode = 'unified'
       } = args;
 
-      const notebookWidget = getNotebookWidget(
+      const notebookWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
@@ -588,7 +644,11 @@ function registerSetCellContentCommand(
       }
 
       const targetNotebookPath = notebookWidget.context.path;
-      const { cell: targetCell } = getCellTarget(notebookWidget, cellId);
+      const { cell: targetCell } = getCellTarget(
+        notebookWidget.context.model,
+        cellId,
+        notebookWidget
+      );
 
       const sharedModel = targetCell.sharedModel;
       const previousContent = sharedModel.getSource();
@@ -674,7 +734,7 @@ function registerRunCellCommand(
     execute: async (args: any) => {
       const { notebookPath, cellId, background, recordTiming = true } = args;
 
-      const currentWidget = getNotebookWidget(
+      const currentWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
@@ -689,10 +749,11 @@ function registerRunCellCommand(
       }
 
       const notebook = currentWidget.content;
-      const model = getNotebookModel(currentWidget);
+      const model = currentWidget.context.model;
       const { cellIndex: targetCellIndex } = getCellTarget(
-        currentWidget,
-        cellId
+        model,
+        cellId,
+        currentWidget
       );
       const cellWidget = notebook.widgets[targetCellIndex];
       if (!cellWidget) {
@@ -849,10 +910,10 @@ function registerDeleteCellCommand(
         required: ['cellId']
       }
     },
-    execute: (args: any) => {
+    execute: async (args: any) => {
       const { notebookPath, cellId, background } = args;
 
-      const currentWidget = getNotebookWidget(
+      const currentWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
@@ -866,10 +927,11 @@ function registerDeleteCellCommand(
         );
       }
 
-      const model = getNotebookModel(currentWidget);
+      const model = currentWidget.context.model;
       const { cellIndex: targetCellIndex } = getCellTarget(
-        currentWidget,
-        cellId
+        model,
+        cellId,
+        currentWidget
       );
 
       model.sharedModel.deleteCell(targetCellIndex);
@@ -917,7 +979,7 @@ function registerSaveNotebookCommand(
     execute: async (args: any) => {
       const { notebookPath, background } = args;
 
-      const currentWidget = getNotebookWidget(
+      const currentWidget = await getNotebookWidget(
         notebookPath,
         docManager,
         notebookTracker,
@@ -951,7 +1013,7 @@ function registerSaveNotebookCommand(
 export interface IRegisterNotebookCommandsOptions {
   commands: CommandRegistry;
   docManager: IDocumentManager;
-  kernelSpecManager: KernelSpec.IManager;
+  serviceManager: ServiceManager.IManager;
   notebookTracker?: INotebookTracker;
 }
 
@@ -961,12 +1023,26 @@ export interface IRegisterNotebookCommandsOptions {
 export function registerNotebookCommands(
   options: IRegisterNotebookCommandsOptions
 ): void {
-  const { commands, docManager, kernelSpecManager, notebookTracker } = options;
+  const { commands, docManager, serviceManager, notebookTracker } = options;
 
-  registerCreateNotebookCommand(commands, docManager, kernelSpecManager);
+  registerCreateNotebookCommand(
+    commands,
+    docManager,
+    serviceManager.kernelspecs
+  );
   registerAddCellCommand(commands, docManager, notebookTracker);
-  registerGetNotebookInfoCommand(commands, docManager, notebookTracker);
-  registerGetCellInfoCommand(commands, docManager, notebookTracker);
+  registerGetNotebookInfoCommand(
+    commands,
+    docManager,
+    notebookTracker,
+    serviceManager
+  );
+  registerGetCellInfoCommand(
+    commands,
+    docManager,
+    notebookTracker,
+    serviceManager
+  );
   registerSetCellContentCommand(commands, docManager, notebookTracker);
   registerRunCellCommand(commands, docManager, notebookTracker);
   registerDeleteCellCommand(commands, docManager, notebookTracker);

--- a/src/notebook-commands.ts
+++ b/src/notebook-commands.ts
@@ -445,6 +445,7 @@ function registerGetNotebookInfoCommand(
       const activeCell = notebook?.activeCell;
       const activeCellId = activeCell?.model.id || null;
       const activeCellType = activeCell?.model.type || 'unknown';
+      const isDirty = model.dirty;
       const cells = Array.from({ length: cellCount }, (_, index) => {
         const cell = model.cells.get(index);
 
@@ -454,6 +455,11 @@ function registerGetNotebookInfoCommand(
         };
       });
       const notebookMetadata = model.metadata;
+
+      if (!currentWidget) {
+        context.dispose();
+      }
+
       return {
         success: true,
         notebookName:
@@ -464,7 +470,7 @@ function registerGetNotebookInfoCommand(
         activeCellType,
         cells,
         notebookMetadata,
-        isDirty: model.dirty
+        isDirty
       };
     }
   };
@@ -554,6 +560,10 @@ function registerGetCellInfoCommand(
       if (cellType === 'code') {
         const rawOutputs = sharedModel.toJSON().outputs;
         outputs = Array.isArray(rawOutputs) ? rawOutputs : [];
+      }
+
+      if (!currentWidget) {
+        context.dispose();
       }
 
       return {

--- a/ui-tests/jupyter_server_test_config.py
+++ b/ui-tests/jupyter_server_test_config.py
@@ -15,3 +15,5 @@ c.ServerApp.port = int(os.environ.get("JL_UI_TEST_PORT", "8888"))
 
 # Uncomment to set server log level to debug level
 # c.ServerApp.log_level = "DEBUG"
+
+c.FileContentsManager.delete_to_trash = False

--- a/ui-tests/tests/file_commands.spec.ts
+++ b/ui-tests/tests/file_commands.spec.ts
@@ -61,4 +61,41 @@ test.describe('File Commands', () => {
     expect(copiedInfo.content).toBe(sourceInfo.content);
     expect(copiedInfo.content).toBe('print("alpha")\n');
   });
+
+  test('Should get file info without opening the widget', async ({
+    page,
+    tmpPath
+  }) => {
+    const filename = 'test.txt';
+    const filePath = `${tmpPath}/${filename}`;
+    await page.contents.uploadContent('Test content', 'text', filePath);
+    const fileInfo = await executeCommand(page, COMMANDS.getFileInfo, {
+      filePath
+    });
+    expect(fileInfo.success).toBe(true);
+    expect(fileInfo.filePath).toBe(filePath);
+    expect(fileInfo.content).toBe('Test content');
+
+    expect(page.activity.getTabLocator(filename)).toHaveCount(0);
+    await page.contents.deleteFile(filePath);
+  });
+
+  test('Should get file info and open the widget', async ({
+    page,
+    tmpPath
+  }) => {
+    const filename = 'test.txt';
+    const filePath = `${tmpPath}/${filename}`;
+    await page.contents.uploadContent('Test content', 'text', filePath);
+    const fileInfo = await executeCommand(page, COMMANDS.getFileInfo, {
+      filePath,
+      createWidget: true
+    });
+    expect(fileInfo.success).toBe(true);
+    expect(fileInfo.filePath).toBe(filePath);
+    expect(fileInfo.content).toBe('Test content');
+
+    expect(page.activity.getTabLocator(filename)).toHaveCount(1);
+    await page.contents.deleteFile(filePath);
+  });
 });

--- a/ui-tests/tests/notebook_commands.spec.ts
+++ b/ui-tests/tests/notebook_commands.spec.ts
@@ -278,3 +278,77 @@ test.describe('Notebook Commands', () => {
     expect(output?.[0].trim()).toBe('alpha');
   });
 });
+
+test.describe('Opening Notebook widget', () => {
+  test.use({ serverFiles: 'only-on-failure' });
+  const notebookName = 'get-notebook-info.ipynb';
+
+  test.beforeEach(async ({ page }) => {
+    await page.notebook.createNew(notebookName);
+    await page.notebook.setCell(0, 'markdown', '# Title\nBody');
+    await page.notebook.save();
+    await page.notebook.close();
+  });
+
+  test.afterEach(async ({ page, tmpPath }) => {
+    const notebookPath = `${tmpPath}/${notebookName}`;
+    await page.contents.deleteFile(notebookPath);
+  });
+
+  test('Should get notebook and cell info without opening the widget', async ({
+    page,
+    tmpPath
+  }) => {
+    const notebookPath = `${tmpPath}/${notebookName}`;
+
+    const notebookInfo = await executeCommand(page, COMMANDS.getNotebookInfo, {
+      notebookPath
+    });
+    expect(notebookInfo.success).toBe(true);
+    expect(notebookInfo.notebookPath).toBe(notebookPath);
+    expect(notebookInfo.cellCount).toBe(1);
+    const cellId = notebookInfo.cells[0].cellId;
+
+    expect(page.activity.getTabLocator(notebookName)).toHaveCount(0);
+
+    const cellInfo = await executeCommand(page, COMMANDS.getCellInfo, {
+      notebookPath,
+      cellId
+    });
+
+    expect(cellInfo.success).toBe(true);
+    expect(cellInfo.cellId).toBe(cellId);
+    expect(cellInfo.cellType).toBe('markdown');
+    expect(page.activity.getTabLocator(notebookName)).toHaveCount(0);
+  });
+
+  test('Should get notebook and cell info and open the widget', async ({
+    page,
+    tmpPath
+  }) => {
+    const notebookPath = `${tmpPath}/${notebookName}`;
+
+    const notebookInfo = await executeCommand(page, COMMANDS.getNotebookInfo, {
+      notebookPath,
+      createWidget: true
+    });
+    expect(notebookInfo.success).toBe(true);
+    expect(notebookInfo.notebookPath).toBe(notebookPath);
+    expect(notebookInfo.cellCount).toBe(1);
+    const cellId = notebookInfo.cells[0].cellId;
+
+    expect(page.activity.getTabLocator(notebookName)).toHaveCount(1);
+    await page.notebook.close();
+
+    const cellInfo = await executeCommand(page, COMMANDS.getCellInfo, {
+      notebookPath,
+      cellId,
+      createWidget: true
+    });
+
+    expect(cellInfo.success).toBe(true);
+    expect(cellInfo.cellId).toBe(cellId);
+    expect(cellInfo.cellType).toBe('markdown');
+    expect(page.activity.getTabLocator(notebookName)).toHaveCount(1);
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -4165,6 +4165,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "jupyterlab-ai-commands@workspace:."
   dependencies:
+    "@jupyter/ydoc": ^3.1.0
     "@jupyterlab/application": ^4.0.0
     "@jupyterlab/apputils": ^4.0.0
     "@jupyterlab/builder": ^4.0.0


### PR DESCRIPTION
This PR allows to get the content of notebook, cell or document without opening the widget.
There is a new option `createWidget` in the related commands, that is set to `false` by default.

This may be less disruptive when an agent is searching for content. Otherwise, it may end up opening a large number of files just to find a specific content.

Related to https://github.com/jupyterlite/ai/issues/313