### PR TITLE
Reposition widgets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import {
+  ILabShell,
   JupyterFrontEnd,
   JupyterFrontEndPlugin
 } from '@jupyterlab/application';
@@ -10,6 +11,7 @@ import { ISettingRegistry } from '@jupyterlab/settingregistry';
 
 import { registerFileCommands } from './file-commands';
 import { registerKernelCommands } from './kernel-commands';
+import { registerLayoutCommands } from './layout-commands';
 import { registerNotebookCommands } from './notebook-commands';
 
 /**
@@ -20,11 +22,12 @@ const plugin: JupyterFrontEndPlugin<void> = {
   description: 'A set of commands for AI in JupyterLab',
   autoStart: true,
   requires: [IDocumentManager],
-  optional: [IEditorTracker, INotebookTracker, ISettingRegistry],
+  optional: [IEditorTracker, ILabShell, INotebookTracker, ISettingRegistry],
   activate: (
     app: JupyterFrontEnd,
     docManager: IDocumentManager,
     editorTracker?: IEditorTracker,
+    labShell?: ILabShell,
     notebookTracker?: INotebookTracker,
     settingRegistry?: ISettingRegistry
   ) => {
@@ -51,6 +54,11 @@ const plugin: JupyterFrontEndPlugin<void> = {
       commands,
       kernelManager,
       kernelSpecManager: serviceManager.kernelspecs
+    });
+
+    registerLayoutCommands({
+      commands,
+      labShell
     });
 
     if (settingRegistry) {

--- a/src/layout-commands.ts
+++ b/src/layout-commands.ts
@@ -1,0 +1,79 @@
+import { ILabShell } from '@jupyterlab/application';
+import { CommandRegistry } from '@lumino/commands';
+
+/**
+ *
+ */
+function registerRepositionWidgetCommand(
+  commands: CommandRegistry,
+  labShell: ILabShell
+): void {
+  const command = {
+    id: 'jupyterlab-ai-commands:reposition',
+    label: 'Reposition Widget',
+    caption: 'Reposition a widget in the application shell',
+    describedBy: {
+      args: {
+        type: 'object',
+        properties: {
+          widgetId: {
+            type: 'string',
+            description: 'The widget ID to reposition in the application shell'
+          },
+          area: {
+            type: 'string',
+            description: 'The name of the area to reposition the widget to'
+          },
+          mode: {
+            type: 'string',
+            enum: ['split-left', 'split-right', 'split-top', 'split-bottom'],
+            description: 'The mode to use when repositioning the widget'
+          }
+        }
+      }
+    },
+    execute: (args: any) => {
+      const { widgetId, area, mode } = args;
+      const widget = widgetId
+        ? Array.from(labShell.widgets('main')).find(w => w.id === widgetId) ||
+          labShell.currentWidget
+        : labShell.currentWidget;
+
+      if (!widget) {
+        return;
+      }
+
+      if (area && area !== 'main') {
+        // Move to different area
+        labShell.move(widget, area);
+        labShell.activateById(widget.id);
+      } else if (mode) {
+        // Reposition within main area using split mode
+        labShell.add(widget, 'main', { mode, activate: true });
+      }
+    }
+  };
+
+  commands.addCommand(command.id, command);
+}
+
+/**
+ * Options for registering layout commands
+ */
+export interface IRegisterLayoutCommandsOptions {
+  commands: CommandRegistry;
+  labShell?: ILabShell;
+}
+
+/**
+ * Register all layout related commands
+ */
+export function registerLayoutCommands(
+  options: IRegisterLayoutCommandsOptions
+): void {
+  const { commands, labShell } = options;
+
+  if (labShell) {
+    registerRepositionWidgetCommand(commands, labShell);
+  }
+}

--- a/ui-tests/tests/layout_commands.spec.ts
+++ b/ui-tests/tests/layout_commands.spec.ts
@@ -54,6 +54,11 @@ test.describe('Layout Commands', () => {
     await expect(page.locator('.lm-DockPanel-tabBar')).toHaveCount(
       tabBarsBefore + 1
     );
+
+    // Verify the correct widget (the active notebook) was repositioned
+    await expect(
+      page.locator('.lm-TabBar-tabLabel').filter({ hasText: 'test-split-right' })
+    ).toBeVisible();
   });
 
   test('should split a specific widget by ID to the left', async ({
@@ -85,6 +90,23 @@ test.describe('Layout Commands', () => {
     await expect(page.locator('.lm-DockPanel-tabBar')).toHaveCount(
       tabBarsBefore + 1
     );
+
+    // Verify notebook1 was moved and is in a different tab bar than notebook2
+    await expect(
+      page.locator('.lm-TabBar-tabLabel').filter({ hasText: 'reposition-nb1' })
+    ).toBeVisible();
+    await expect(
+      page.locator('.lm-TabBar-tabLabel').filter({ hasText: 'reposition-nb2' })
+    ).toBeVisible();
+    const inDifferentTabBars = await page.evaluate(() => {
+      const labels = Array.from(document.querySelectorAll('.lm-TabBar-tabLabel'));
+      const nb1Label = labels.find(l => l.textContent?.includes('reposition-nb1'));
+      const nb2Label = labels.find(l => l.textContent?.includes('reposition-nb2'));
+      const nb1TabBar = nb1Label?.closest('.lm-DockPanel-tabBar');
+      const nb2TabBar = nb2Label?.closest('.lm-DockPanel-tabBar');
+      return !!nb1TabBar && !!nb2TabBar && nb1TabBar !== nb2TabBar;
+    });
+    expect(inDifferentTabBars).toBe(true);
   });
 
   test('should move a widget to the right sidebar area', async ({
@@ -105,9 +127,9 @@ test.describe('Layout Commands', () => {
       area: 'right'
     });
 
-    // The widget should now be in the right sidebar.
-    await expect(page.sidebar.getContentPanelLocator('right')).toContainText(
-      'test-move-to-right'
-    );
+    // The widget should now be in the right sidebar — its title appears in the active tab.
+    await expect(
+      page.sidebar.getTabBarLocator('right').locator('.lm-TabBar-tab.lm-mod-current')
+    ).toContainText('test-move-to-right');
   });
 });

--- a/ui-tests/tests/layout_commands.spec.ts
+++ b/ui-tests/tests/layout_commands.spec.ts
@@ -57,7 +57,9 @@ test.describe('Layout Commands', () => {
 
     // Verify the correct widget (the active notebook) was repositioned
     await expect(
-      page.locator('.lm-TabBar-tabLabel').filter({ hasText: 'test-split-right' })
+      page
+        .locator('.lm-TabBar-tabLabel')
+        .filter({ hasText: 'test-split-right' })
     ).toBeVisible();
   });
 
@@ -99,9 +101,15 @@ test.describe('Layout Commands', () => {
       page.locator('.lm-TabBar-tabLabel').filter({ hasText: 'reposition-nb2' })
     ).toBeVisible();
     const inDifferentTabBars = await page.evaluate(() => {
-      const labels = Array.from(document.querySelectorAll('.lm-TabBar-tabLabel'));
-      const nb1Label = labels.find(l => l.textContent?.includes('reposition-nb1'));
-      const nb2Label = labels.find(l => l.textContent?.includes('reposition-nb2'));
+      const labels = Array.from(
+        document.querySelectorAll('.lm-TabBar-tabLabel')
+      );
+      const nb1Label = labels.find(l =>
+        l.textContent?.includes('reposition-nb1')
+      );
+      const nb2Label = labels.find(l =>
+        l.textContent?.includes('reposition-nb2')
+      );
       const nb1TabBar = nb1Label?.closest('.lm-DockPanel-tabBar');
       const nb2TabBar = nb2Label?.closest('.lm-DockPanel-tabBar');
       return !!nb1TabBar && !!nb2TabBar && nb1TabBar !== nb2TabBar;
@@ -129,7 +137,9 @@ test.describe('Layout Commands', () => {
 
     // The widget should now be in the right sidebar — its title appears in the active tab.
     await expect(
-      page.sidebar.getTabBarLocator('right').locator('.lm-TabBar-tab.lm-mod-current')
+      page.sidebar
+        .getTabBarLocator('right')
+        .locator('.lm-TabBar-tab.lm-mod-current')
     ).toContainText('test-move-to-right');
   });
 });

--- a/ui-tests/tests/layout_commands.spec.ts
+++ b/ui-tests/tests/layout_commands.spec.ts
@@ -1,0 +1,113 @@
+import { expect, test } from '@jupyterlab/galata';
+import { executeCommand } from './utils/commands';
+
+const COMMANDS = {
+  reposition: 'jupyterlab-ai-commands:reposition',
+  createNotebook: 'jupyterlab-ai-commands:create-notebook'
+} as const;
+
+async function getWidgetIdByPath(
+  page: any,
+  path: string
+): Promise<string | undefined> {
+  return page.evaluate(async (notebookPath: string) => {
+    await window.jupyterapp.started;
+    const widgets = Array.from(window.jupyterapp.shell.widgets('main'));
+    return (widgets.find((w: any) => w.context?.path === notebookPath) as any)
+      ?.id;
+  }, path);
+}
+
+test.describe('Layout Commands', () => {
+  test.use({ serverFiles: 'only-on-failure' });
+
+  test('should silently do nothing when no widget is found', async ({
+    page
+  }) => {
+    // Use a widget ID that does not exist and has no current widget fallback
+    // by evaluating directly so no widget will be returned.
+    const result = await page.evaluate(async () => {
+      await window.jupyterapp.started;
+      return window.jupyterapp.commands.execute(
+        'jupyterlab-ai-commands:reposition',
+        { widgetId: '__non_existent_widget_id__', mode: 'split-right' }
+      );
+    });
+    // Command returns undefined and does not throw.
+    expect(result).toBeUndefined();
+  });
+
+  test('should split the active widget to the right', async ({
+    page,
+    tmpPath
+  }) => {
+    const notebookPath = `${tmpPath}/test-split-right.ipynb`;
+    await executeCommand(page, COMMANDS.createNotebook, {
+      name: notebookPath,
+      language: 'python'
+    });
+
+    const tabBarsBefore = await page.locator('.lm-DockPanel-tabBar').count();
+
+    await executeCommand(page, COMMANDS.reposition, { mode: 'split-right' });
+
+    await expect(page.locator('.lm-DockPanel-tabBar')).toHaveCount(
+      tabBarsBefore + 1
+    );
+  });
+
+  test('should split a specific widget by ID to the left', async ({
+    page,
+    tmpPath
+  }) => {
+    const notebook1 = `${tmpPath}/reposition-nb1.ipynb`;
+    const notebook2 = `${tmpPath}/reposition-nb2.ipynb`;
+
+    await executeCommand(page, COMMANDS.createNotebook, {
+      name: notebook1,
+      language: 'python'
+    });
+    await executeCommand(page, COMMANDS.createNotebook, {
+      name: notebook2,
+      language: 'python'
+    });
+
+    const widgetId = await getWidgetIdByPath(page, notebook1);
+    expect(widgetId).toBeTruthy();
+
+    const tabBarsBefore = await page.locator('.lm-DockPanel-tabBar').count();
+
+    await executeCommand(page, COMMANDS.reposition, {
+      widgetId,
+      mode: 'split-left'
+    });
+
+    await expect(page.locator('.lm-DockPanel-tabBar')).toHaveCount(
+      tabBarsBefore + 1
+    );
+  });
+
+  test('should move a widget to the right sidebar area', async ({
+    page,
+    tmpPath
+  }) => {
+    const notebookPath = `${tmpPath}/test-move-to-right.ipynb`;
+    await executeCommand(page, COMMANDS.createNotebook, {
+      name: notebookPath,
+      language: 'python'
+    });
+
+    const widgetId = await getWidgetIdByPath(page, notebookPath);
+    expect(widgetId).toBeTruthy();
+
+    await executeCommand(page, COMMANDS.reposition, {
+      widgetId,
+      area: 'right'
+    });
+
+    // The widget should now be in the right sidebar.
+    await expect(page.sidebar.getContentPanelLocator('right')).toContainText(
+      'test-move-to-right'
+    );
+  });
+});


### PR DESCRIPTION
Add a command to reposition widgets in the lab shell.

This PR may have to be updated if #24 goes first, or the other way around, to handle the user facing strings localization.

This command initially comes from `jupyterlite-ai`: https://github.com/jupyterlite/ai/blob/9ef5e207a02a2d25d22701fa20ab676ec6a87040/packages/ai/src/index.ts#L739